### PR TITLE
Added another method to be able to set options

### DIFF
--- a/Snappy/LoggableGenerator.php
+++ b/Snappy/LoggableGenerator.php
@@ -77,6 +77,16 @@ class LoggableGenerator implements GeneratorInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function setOption($name, $value)
+    {
+        $this->logDebug(sprintf('Set option %s = %s.', $name, $value));
+
+        return $this->generator->setOption($name, $value);
+    }
+    
+    /**
      * Logs the given debug message if the logger is configured or do nothing
      * otherwise
      *


### PR DESCRIPTION
Not sure why something so simple but necessary is missing from this interface to Snappy. 
I just added a new option to be able to set options before generating the PDF document.
