### PR TITLE
Fix missing "extra" node for branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,11 @@
             "Knp\\Bundle\\SnappyBundle": ""
         }
     },
-    "branch-alias": {
-        "dev-master": "1.0-dev"
+    
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     },
 
     "target-dir": "Knp/Bundle/SnappyBundle"


### PR DESCRIPTION
The branch alias doesn't appear on packagist. This could help :)
