### PR TITLE
set 'generator' argument type to AbstractGenerator

### DIFF
--- a/Snappy/LoggableGenerator.php
+++ b/Snappy/LoggableGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Bundle\SnappyBundle\Snappy;
 
+use Knp\Snappy\AbstractGenerator;
 use Knp\Snappy\GeneratorInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
@@ -17,10 +18,10 @@ class LoggableGenerator implements GeneratorInterface
     /**
      * Constructor
      *
-     * @param GeneratorInterface $generator
-     * @param LoggerInterface    $logger
+     * @param AbstractGenerator $generator
+     * @param LoggerInterface   $logger
      */
-    public function __construct(GeneratorInterface $generator, LoggerInterface $logger = null)
+    public function __construct(AbstractGenerator $generator, LoggerInterface $logger = null)
     {
         $this->generator = $generator;
         $this->logger = $logger;

--- a/Tests/Snappy/LoggableGeneratorTest.php
+++ b/Tests/Snappy/LoggableGeneratorTest.php
@@ -6,9 +6,40 @@ use Knp\Bundle\SnappyBundle\Snappy\LoggableGenerator;
 
 class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
 {
+    private $generator;
+
+    protected function setUp()
+    {
+        $this->generator = $this->getMockForAbstractClass(
+            'Knp\Snappy\AbstractGenerator',
+            array(
+                'the_binary',
+                array()
+            ),
+            '',
+            true,
+            true,
+            true,
+            array(
+                'generate',
+                'getOutput',
+                'setOption',
+                'getOutputFromHtml',
+                'generateFromHtml',
+                'configure',
+                'prepareOutput',
+                'getCommand',
+                'executeCommand',
+                'checkOutput',
+                'checkProcessStatus',
+            )
+        );
+    }
+
     public function testGenerate()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->generator;
+
         $internal
             ->expects($this->once())
             ->method('generate')
@@ -33,7 +64,7 @@ class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateFromHtml()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->generator;
         $internal
             ->expects($this->once())
             ->method('generateFromHtml')
@@ -58,7 +89,7 @@ class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testOutput()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->generator;
         $internal
             ->expects($this->once())
             ->method('getOutput')
@@ -81,7 +112,7 @@ class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testOutputFromHtml()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->generator;
         $internal
             ->expects($this->once())
             ->method('getOutputFromHtml')
@@ -104,7 +135,7 @@ class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testOutputFromHtmlWithHtmlArray()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->generator;
         $internal
             ->expects($this->once())
             ->method('getOutputFromHtml')
@@ -127,7 +158,7 @@ class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetOption()
     {
-        $internal = $this->getMock('Knp\Snappy\Image');
+        $internal = $this->generator;
         $internal
             ->expects($this->at(0))
             ->method('setOption')


### PR DESCRIPTION
Hello,

I've been using the KnpSnappyBundle, and I've noticed that maybe the object required by the 'LoggableGenerator' constructor, the generator itself, needs to implement the 'setOption' method, which doesn't, as it is called internally in a 'LoggableGenerator' method also called 'setOption'.

Right now, the constructor of LoggableGenerator expects as a 'generator' an object implementing the 'GeneretorInterface', but the required method mentioned before ('setOption') is not defined in that interface, but in the 'Knp\Snappy\AbstractGenerator' class.

The unit test provided in the bundle, when testing the setOption method, uses a 'Knp\Snappy\Image' mock, instead of a 'Knp\Snappy\GeneratorInterface'. The 'Image' class implements the GeneratorInterface but also extends AbstractGenerator class, which avoids the test's failure.

I've been working on different options, and in my opinion, and due this bundle class acts as a wrapper for the 'Knp\Snappy\' generators, the less harmful option is requiring an 'AbstractGenerator' on the 'LoggableGenerator' constructor as the internal generator.
