### PR TITLE
Add timeout option from configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,10 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('temporary_folder')->end()
+                ->integerNode('process_timeout')
+                    ->min(1)
+                    ->info('Generator process timeout. Be aware that only works with Symfony process component.')
+                ->end()
                 ->arrayNode('pdf')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/KnpSnappyExtension.php
+++ b/DependencyInjection/KnpSnappyExtension.php
@@ -30,6 +30,10 @@ class KnpSnappyExtension extends Extension
                 $container->findDefinition('knp_snappy.pdf.internal_generator')
                     ->addMethodCall('setTemporaryFolder', array($config['temporary_folder']));
             }
+            if (!empty($config['process_timeout'])) {
+                $container->findDefinition('knp_snappy.pdf.internal_generator')
+                    ->addMethodCall('setTimeout', array($config['process_timeout']));
+            }
         }
 
         if ($config['image']['enabled']) {
@@ -40,6 +44,10 @@ class KnpSnappyExtension extends Extension
             if (!empty($config['temporary_folder'])) {
                 $container->findDefinition('knp_snappy.image.internal_generator')
                     ->addMethodCall('setTemporaryFolder', array($config['temporary_folder']));
+            }
+            if (!empty($config['process_timeout'])) {
+                $container->findDefinition('knp_snappy.image.internal_generator')
+                    ->addMethodCall('setTimeout', array($config['process_timeout']));
             }
         }
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -128,7 +128,29 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'env'       => array(),
                     )
                 )
-            )
+            ),
+            array(
+                array(
+                    array(
+                        'process_timeout' => 120,
+                    ),
+                ),
+                array(
+                    'process_timeout' => 120,
+                    'pdf'   => array(
+                        'enabled'   => true,
+                        'binary'    => 'wkhtmltopdf',
+                        'options'   => array(),
+                        'env'       => array(),
+                    ),
+                    'image' => array(
+                        'enabled'   => true,
+                        'binary'    => 'wkhtmltoimage',
+                        'options'   => array(),
+                        'env'       => array(),
+                    ),
+                )
+            ),
         );
     }
 }


### PR DESCRIPTION
Snappy generator has a timeout option for Symfony process with a setter.

This PR propose to add the possibility to set default timeout via configuration.
