### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,7 @@ before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-up
 
 install: composer update --prefer-dist
 
-script: phpunit
+script:
+  - composer show symfony/security-csrf
+  - composer why symfony/security-csrf
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,4 @@ before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-up
 install: composer update --prefer-dist
 
 script:
-  - composer show symfony/security-csrf
-  - composer why symfony/security-csrf
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,19 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
   
 matrix:
   include:
     - php: 5.6
-      env: SYMFONY_VERSION="2.3.*"
-    - php: 5.6
+      env: SYMFONY_VERSION="3.4.*@dev"
+    - php: 7.0
       env: SYMFONY_VERSION="2.8.*@dev symfony/phpunit-bridge:~2.7"
-    - php: 5.6
-      env: SYMFONY_VERSION="3.0.*@dev"
+    - php: 7.1
+      env: SYMFONY_VERSION="2.7.*@dev"
   fast_finish: true
 
 before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## v2.0
+
+* Drop support for php v5.3, 5.4, 5.5
+* Drop support for symfony below v2.7

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,6 @@
     "require": {
         "php":                      ">=5.3.2",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/finder":           "~2.3|~3.0",
-        "symfony/validator":        "~2.3|~3.0",
         "knplabs/knp-snappy":       "~0.1"
     },
 
@@ -37,6 +35,11 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5"
+        "doctrine/annotations": "~1.0",
+        "phpunit/phpunit": "~4.5",
+        "symfony/finder": "~2.3|~3.0",
+        "symfony/security-csrf": "~2.4",
+        "symfony/templating": "~2.1|~3.0",
+        "symfony/validator": "~2.3|~3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
 
     "require": {
-        "php":                      ">=5.3.2",
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "php":                      ">=5.6",
+        "symfony/framework-bundle": "~2.7|~3.0",
         "knplabs/knp-snappy":       "~0.1"
     },
 
@@ -31,15 +31,16 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
         "phpunit/phpunit": "~4.5",
-        "symfony/finder": "~2.3|~3.0",
-        "symfony/security-csrf": "~2.4",
-        "symfony/templating": "~2.1|~3.0",
-        "symfony/validator": "~2.3|~3.0"
+        "symfony/asset": "~2.7|~3.0",
+        "symfony/finder": "~2.7|~3.0",
+        "symfony/security-csrf": "~2.7|~3.0",
+        "symfony/templating": "~2.7|~3.0",
+        "symfony/validator": "~2.7|~3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,8 @@
         "branch-alias": {
             "dev-master": "1.5.x-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.5"
     }
 }


### PR DESCRIPTION
Builds on Travis are broken since ~6 months. This patch adds phpunit as a dev deps of the library and run the tests using it, rather than using the global binary provided by Travis.