### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -2,9 +2,10 @@
 
 namespace Knp\Bundle\SnappyBundle\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * @dataProvider dataForProcessedConfiguration

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -2,9 +2,10 @@
 
 namespace Knp\Bundle\SnappyBundle\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
     /** @var TestKernel */
     private $kernel;

--- a/Tests/Snappy/Generator/LoggableGeneratorTest.php
+++ b/Tests/Snappy/Generator/LoggableGeneratorTest.php
@@ -3,11 +3,12 @@
 namespace Knp\Bundle\SnappyBundle\Tests\Snappy;
 
 use Knp\Bundle\SnappyBundle\Snappy\Generator\LoggableGenerator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group legacy
  */
-class LoggableGeneratorTest extends \PHPUnit_Framework_TestCase
+class LoggableGeneratorTest extends TestCase
 {
     public function testGenerate()
     {

--- a/Tests/Snappy/Response/JpegResponseTest.php
+++ b/Tests/Snappy/Response/JpegResponseTest.php
@@ -3,8 +3,9 @@
 namespace Knp\Bundle\SnappyBundle\Tests\Snappy;
 
 use Knp\Bundle\SnappyBundle\Snappy\Response\JpegResponse;
+use PHPUnit\Framework\TestCase;
 
-class JpegResponseTest extends \PHPUnit_Framework_TestCase
+class JpegResponseTest extends TestCase
 {
     public function testDefaultParameters()
     {

--- a/Tests/Snappy/Response/PdfResponseTest.php
+++ b/Tests/Snappy/Response/PdfResponseTest.php
@@ -3,8 +3,9 @@
 namespace Knp\Bundle\SnappyBundle\Tests\Snappy;
 
 use Knp\Bundle\SnappyBundle\Snappy\Response\PdfResponse;
+use PHPUnit\Framework\TestCase;
 
-class PdfResponseTest extends \PHPUnit_Framework_TestCase
+class PdfResponseTest extends TestCase
 {
     public function testDefaultParameters()
     {

--- a/Tests/Snappy/Response/SnappyResponseTest.php
+++ b/Tests/Snappy/Response/SnappyResponseTest.php
@@ -3,8 +3,9 @@
 namespace Knp\Bundle\SnappyBundle\Tests\Snappy;
 
 use Knp\Bundle\SnappyBundle\Snappy\Response\SnappyResponse;
+use PHPUnit\Framework\TestCase;
 
-class SnappyResponseTest extends \PHPUnit_Framework_TestCase
+class SnappyResponseTest extends TestCase
 {
     public function testExceptionMessage()
     {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~4.8.35",
         "symfony/asset": "~2.7|~3.0|^4.0",
         "symfony/finder": "~2.7|~3.0|^4.0",
         "symfony/security-csrf": "~2.7|~3.0|^4.0",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.