### PR TITLE
Corrected typo in README example "Render a pdf document with a relati…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -162,7 +162,7 @@ class SomeController extends Controller
         $pageUrl = $this->generateUrl('homepage', array(), true); // use absolute path!
 
         return new PdfResponse(
-            $this->get('knp_snappy.pdf')->getOutput($html),
+            $this->get('knp_snappy.pdf')->getOutput($pageUrl),
             'file.pdf'
         );
     }


### PR DESCRIPTION
Corrected typo in README example "Render a pdf document with a relative url inside like css files".

```
$pageUrl = $this->generateUrl('homepage', array(), true); // use absolute path!

return new PdfResponse(
    $this->get('knp_snappy.pdf')->getOutput($html),
    'file.pdf'
);
```

It should be `$this->get('knp_snappy.pdf')->getOutput($pageUrl),`