### PR TITLE
Drop unsupported PHP versions from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: php
-dist: trusty
-
-sudo: false
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,17 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
-  - hhvm
-  
+  - 7.2
+  - 7.3
+
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
+      env: SYMFONY_VERSION="4.3.*@dev"
+    - php: 7.3
       env: SYMFONY_VERSION="3.4.*@dev"
-    - php: 7.0
-      env: SYMFONY_VERSION="2.8.*@dev symfony/phpunit-bridge:~2.7"
-    - php: 7.1
-      env: SYMFONY_VERSION="2.7.*@dev"
-    - php: 7.1
+    - php: 7.2
       env: DEPENDENCIES=beta
   fast_finish: true
 

--- a/Tests/Snappy/Generator/LoggableGeneratorTest.php
+++ b/Tests/Snappy/Generator/LoggableGeneratorTest.php
@@ -12,7 +12,7 @@ class LoggableGeneratorTest extends TestCase
 {
     public function testGenerate()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->createMock('Knp\Snappy\GeneratorInterface');
         $internal
             ->expects($this->once())
             ->method('generate')
@@ -23,7 +23,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(true)
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('debug')
@@ -35,7 +35,7 @@ class LoggableGeneratorTest extends TestCase
 
     public function testGenerateFromHtml()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->createMock('Knp\Snappy\GeneratorInterface');
         $internal
             ->expects($this->once())
             ->method('generateFromHtml')
@@ -46,7 +46,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(true)
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('debug')
@@ -58,7 +58,7 @@ class LoggableGeneratorTest extends TestCase
 
     public function testGenerateFromHtmlWithHtmlArray()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->createMock('Knp\Snappy\GeneratorInterface');
         $internal
             ->expects($this->once())
             ->method('generateFromHtml')
@@ -69,7 +69,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(true)
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('debug')
@@ -81,7 +81,7 @@ class LoggableGeneratorTest extends TestCase
 
     public function testOutput()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->createMock('Knp\Snappy\GeneratorInterface');
         $internal
             ->expects($this->once())
             ->method('getOutput')
@@ -90,7 +90,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(['foo' => 'bar'])
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('debug')
@@ -102,7 +102,7 @@ class LoggableGeneratorTest extends TestCase
 
     public function testOutputFromHtml()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->createMock('Knp\Snappy\GeneratorInterface');
         $internal
             ->expects($this->once())
             ->method('getOutputFromHtml')
@@ -111,7 +111,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(['foo' => 'bar'])
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('debug')
@@ -123,7 +123,7 @@ class LoggableGeneratorTest extends TestCase
 
     public function testOutputFromHtmlWithHtmlArray()
     {
-        $internal = $this->getMock('Knp\Snappy\GeneratorInterface');
+        $internal = $this->createMock('Knp\Snappy\GeneratorInterface');
         $internal
             ->expects($this->once())
             ->method('getOutputFromHtml')
@@ -132,7 +132,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(['foo' => 'bar'])
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->once())
             ->method('debug')
@@ -144,7 +144,7 @@ class LoggableGeneratorTest extends TestCase
 
     public function testSetOption()
     {
-        $internal = $this->getMock('Knp\Snappy\Image');
+        $internal = $this->createMock('Knp\Snappy\Image');
         $internal
             ->expects($this->at(0))
             ->method('setOption')
@@ -160,7 +160,7 @@ class LoggableGeneratorTest extends TestCase
                 $this->equalTo(['bar'=>'baz'])
             );
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
             ->expects($this->at(0))
             ->method('debug')

--- a/Tests/Snappy/Response/JpegResponseTest.php
+++ b/Tests/Snappy/Response/JpegResponseTest.php
@@ -14,7 +14,7 @@ class JpegResponseTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('some_binary_output', $response->getContent());
         $this->assertSame('image/jpg', $response->headers->get('Content-Type'));
-        $this->assertSame('inline; filename="output.jpg"', $response->headers->get('Content-Disposition'));
+        $this->assertSame('inline; filename=output.jpg', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
     public function testSetDifferentMimeType()
@@ -28,9 +28,9 @@ class JpegResponseTest extends TestCase
     {
         $fileName = 'test.jpg';
         $response = new JpegResponse('some_binary_output', $fileName);
-        $fileNameFromDispositionRegex = '/.*filename="([^"]+)"/';
+        $fileNameFromDispositionRegex = '/.*filename=([^"]+)/';
 
-        $this->assertSame(1, preg_match($fileNameFromDispositionRegex, $response->headers->get('Content-Disposition'), $matches), 1);
+        $this->assertSame(1, preg_match($fileNameFromDispositionRegex, str_replace('"', '', $response->headers->get('Content-Disposition')), $matches), 1);
 
         $this->assertSame($fileName, $matches[1]);
     }

--- a/Tests/Snappy/Response/PdfResponseTest.php
+++ b/Tests/Snappy/Response/PdfResponseTest.php
@@ -14,7 +14,7 @@ class PdfResponseTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('some_binary_output', $response->getContent());
         $this->assertSame('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertSame('attachment; filename="output.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertSame('attachment; filename=output.pdf', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
     public function testSetDifferentMimeType()
@@ -28,9 +28,9 @@ class PdfResponseTest extends TestCase
     {
         $fileName = 'test.pdf';
         $response = new PdfResponse('some_binary_output', $fileName);
-        $fileNameFromDispositionRegex = '/.*filename="([^"]+)"/';
+        $fileNameFromDispositionRegex = '/.*filename=([^"]+)/';
 
-        $this->assertSame(1, preg_match($fileNameFromDispositionRegex, $response->headers->get('Content-Disposition'), $matches), 1);
+        $this->assertSame(1, preg_match($fileNameFromDispositionRegex, str_replace('"', '', $response->headers->get('Content-Disposition')), $matches), 1);
 
         $this->assertSame($fileName, $matches[1]);
     }

--- a/Tests/fixtures/config/base.yml
+++ b/Tests/fixtures/config/base.yml
@@ -5,4 +5,3 @@ framework:
     validation:      { enabled: true, enable_annotations: true }
     templating:      { engines: ['php'] } #assets_version: SomeVersionScheme
     session:         ~
-    translator:      { fallback: en }

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "symfony/finder": "~2.7|~3.0|^4.0",
         "symfony/security-csrf": "~2.7|~3.0|^4.0",
         "symfony/templating": "~2.7|~3.0|^4.0",
-        "symfony/translation": "~2.7|~3.0|^4.0",
         "symfony/validator": "~2.7|~3.0|^4.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,12 @@
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
-        "phpunit/phpunit": "~4.8.35",
+        "phpunit/phpunit": "~7.4",
         "symfony/asset": "~2.7|~3.0|^4.0",
         "symfony/finder": "~2.7|~3.0|^4.0",
         "symfony/security-csrf": "~2.7|~3.0|^4.0",
         "symfony/templating": "~2.7|~3.0|^4.0",
-        "symfony/validator": "~2.7|~3.0|^4.0"
+        "symfony/validator": "~2.7|~3.0|^4.0",
+        "symfony/yaml": "~3.0|~4.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/finder": "~2.7|~3.0|^4.0",
         "symfony/security-csrf": "~2.7|~3.0|^4.0",
         "symfony/templating": "~2.7|~3.0|^4.0",
+        "symfony/translation": "~2.7|~3.0|^4.0",
         "symfony/validator": "~2.7|~3.0|^4.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
 
     "require": {
-        "php":                      ">=5.6",
+        "php":                      ">=7.1",
         "symfony/framework-bundle": "~2.7|~3.0|^4.0",
         "knplabs/knp-snappy":       "~1.0,>=1.0.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,28 +11,11 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
-    bootstrap                   = "./Tests/bootstrap.php.dist" >
+    bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>
         <testsuite name="KnpSnappyBundle Test Suite">
             <directory>./Tests</directory>
         </testsuite>
     </testsuites>
-
-    <php>
-        <server name="SYMFONY" value="./Resources/vendor/symfony/src" />
-        <server name="SNAPPY" value="./Resources/vendor/snappy/src" />
-    </php>
-
-
-    <filter>
-        <whitelist>
-            <directory>.</directory>
-            <exclude>
-                <directory>./Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
 </phpunit>


### PR DESCRIPTION
* HHVM is also dropped from the build matrix.
* Use newer versions of PHP in Travis build matrix (7.1, 7.2, 7.3)
* Remove the translation component (not needed)