### PR TITLE
Make the function signature in the implementation match the interface

### DIFF
--- a/src/Snappy/Generator/LoggableGenerator.php
+++ b/src/Snappy/Generator/LoggableGenerator.php
@@ -43,7 +43,7 @@ class LoggableGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($input, $output, array $options = [], $overwrite = false)
+    public function generate($input, string $output, array $options = [], bool $overwrite = false): void
     {
         if (is_array($input)) {
             $debug_input = implode(', ', $input);
@@ -58,7 +58,7 @@ class LoggableGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generateFromHtml($html, $output, array $options = [], $overwrite = false)
+    public function generateFromHtml($html, string $output, array $options = [], bool $overwrite = false): void
     {
         $debugHtml = is_array($html) ? implode(', ', $html) : $html;
 
@@ -70,7 +70,7 @@ class LoggableGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function getOutput($input, array $options = [])
+    public function getOutput($input, array $options = []): string
     {
         if (is_array($input)) {
             $debug_input = implode(', ', $input);
@@ -85,7 +85,7 @@ class LoggableGenerator implements GeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function getOutputFromHtml($html, array $options = [])
+    public function getOutputFromHtml($html, array $options = []): string
     {
         $debugHtml = is_array($html) ? implode(', ', $html) : $html;
 


### PR DESCRIPTION
This fixes the LoggableGenerator implementation function signatures to mirror the changes made in

https://github.com/KnpLabs/snappy/commit/15d05f8d2edcb50e1c1b37786a48cb656c6268ac#diff-853fa2b83054bff2c0389bcfd5b07401