### PR TITLE
Chore/support symfony 7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,9 @@ jobs:
             fail-fast: false
             matrix:
                 include:
+                    - description: 'Symfony 7.1 DEV'
+                      php: '8.2'
+                      symfony: '7.1.*@dev'
                     - description: 'Symfony 7.0'
                       php: '8.3'
                       symfony: '7.0.*'
@@ -35,23 +38,13 @@ jobs:
                     - description: 'Symfony 5.0'
                       php: '8.3'
                       symfony: '5.0.*'
-                    - description: 'Dev deps'
-                      php: '8.3'
-                      symfony: '7.0.*'
-                      dev: true
-                    - description: 'Lowest deps'
+                    - description: 'Beta deps'
                       php: '8.1'
-                      composer_option: '--prefer-lowest'
-                      env:
-                          SYMFONY_DEPRECATIONS_HELPER: max[self]=0
+                      beta: true
         name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
         steps:
             - name: Checkout
               uses: actions/checkout@v3
-            - run: |
-                phpenv config-rm xdebug.ini || true
-                composer global config --no-plugins allow-plugins.symfony/flex true
-                composer global require --no-progress --no-scripts --no-plugins symfony/flex 1.*
             - name: Cache
               uses: actions/cache@v3
               with:
@@ -64,7 +57,9 @@ jobs:
             - run: |
                   sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony }}'"/' composer.json;
               if: matrix.symfony
-            - run: composer config minimum-stability dev && composer config prefer-stable true
-              if: matrix.dev
-            - run: composer update --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
-            - run: vendor/bin/simple-phpunit -v
+            - run: |
+                  composer config minimum-stability dev
+                  composer config prefer-stable true
+              if: matrix.beta
+            - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
+            - run: vendor/bin/phpunit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,24 +20,30 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - description: 'No Symfony specified'
-                      php: '7.4'
+                    - description: 'Symfony 7.0'
+                      php: '8.3'
+                      symfony: '7.0.*'
+                    - description: 'Symfony 6.4'
+                      php: '8.1'
+                      symfony: '6.4.*'
+                    - description: 'Symfony 6.0'
+                      php: '8.3'
+                      symfony: '6.0.*'
+                    - description: 'Symfony 5.4'
+                      php: '8.1'
+                      symfony: '5.4.*'
+                    - description: 'Symfony 5.0'
+                      php: '8.3'
+                      symfony: '5.0.*'
+                    - description: 'Dev deps'
+                      php: '8.3'
+                      symfony: '7.0.*'
+                      dev: true
                     - description: 'Lowest deps'
-                      php: '7.4'
+                      php: '8.1'
                       composer_option: '--prefer-lowest'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: max[self]=0
-                    - description: 'PHP 8.0'
-                      php: '8.0'
-                    - description: 'PHP 8.1'
-                      php: '8.1'
-                    - description: 'PHP 8.2'
-                      php: '8.2'
-                    - description: 'PHP 8.3'
-                      php: '8.3'
-                    - description: 'Dev deps'
-                      php: '8.2'
-                      dev: true
         name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
         steps:
             - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php":                      ">=7.4",
-        "symfony/framework-bundle": "^4.4|^5.1|^6.0",
+        "php":                      ">=8.1",
+        "symfony/framework-bundle": "^5.1|^6.0|^7.0",
         "knplabs/knp-snappy":       "^1.4.3"
     },
     "autoload": {
@@ -31,12 +31,11 @@
         }
     },
     "require-dev": {
-        "symfony/asset": "^4.4|^5.1|^6.0",
-        "symfony/finder": "^4.4|^5.1|^6.0",
-        "symfony/phpunit-bridge": "^4.4|^5.1|^6.0",
-        "symfony/security-csrf": "^4.4|^5.1|^6.0",
-        "symfony/templating": "^4.4|^5.1|^6.0",
-        "symfony/validator": "^4.4|^5.1|^6.0",
-        "symfony/yaml": "^4.4|^5.1|^6.0"
+        "symfony/asset": "^5.1|^6.0|^7.0",
+        "symfony/finder": "^5.1|^6.0|^7.0",
+        "symfony/phpunit-bridge": "^5.1|^6.0|^7.0",
+        "symfony/security-csrf": "^5.1|^6.0|^7.0",
+        "symfony/validator": "^5.1|^6.0|^7.0",
+        "symfony/yaml": "^5.1|^6.0|^7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,7 @@
         }
     },
     "require-dev": {
-        "symfony/asset": "^5.1|^6.0|^7.0",
-        "symfony/finder": "^5.1|^6.0|^7.0",
-        "symfony/phpunit-bridge": "^5.1|^6.0|^7.0",
-        "symfony/security-csrf": "^5.1|^6.0|^7.0",
-        "symfony/validator": "^5.1|^6.0|^7.0",
+        "phpunit/phpunit": "^8.5",
         "symfony/yaml": "^5.1|^6.0|^7.0"
     }
 }

--- a/tests/fixtures/config/base.yml
+++ b/tests/fixtures/config/base.yml
@@ -1,5 +1,1 @@
-framework:
-    secret: ThisIsNotReallyASecretSoPleaseChangeIt
-    router: { resource: "%kernel.project_dir%/config/routing.yml", utf8: true }
-    validation: { enabled: true, enable_annotations: false }
-    http_method_override: false
+framework: ~


### PR DESCRIPTION
Adds:
- support for symfony/symfony 7.x

Removes:
- support for PHP 7.x
- support for symfony/symfony version 3.x and 4.x
- support for psr/log 1