### PR TITLE
feat: fix deprecation for Extension

### DIFF
--- a/src/DependencyInjection/KnpSnappyExtension.php
+++ b/src/DependencyInjection/KnpSnappyExtension.php
@@ -5,8 +5,8 @@ namespace Knp\Bundle\SnappyBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class KnpSnappyExtension extends Extension
 {


### PR DESCRIPTION
`The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Knp\Bundle\SnappyBundle\DependencyInjection\KnpSnappyExtension".`