### PR TITLE
ci: bump ubuntu version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     check:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -15,7 +15,7 @@ jobs:
             - name: Validate composer.json
               run: composer validate --strict --no-check-lock
     tests:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
i am not sure if you want this as a seperate PR to fix the CI.
This change is needed, because ubuntu-20.04 is not supported anymore from GitHub.
