### PR TITLE
Fix service definition

### DIFF
--- a/config/image.php
+++ b/config/image.php
@@ -20,7 +20,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ]
         )
         ->call('setLogger', [service('logger')])
-        ->tag('monolog.setLogger', ['channel' => 'snappy'])
+        ->tag('monolog.logger', ['channel' => 'snappy'])
         ->public()
         ->alias('knp_snappy.image', Knp\Snappy\Image::class)
         ;

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -20,7 +20,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ]
         )
         ->call('setLogger', [service('logger')])
-        ->tag('monolog.setLogger', ['channel' => 'snappy'])
+        ->tag('monolog.logger', ['channel' => 'snappy'])
         ->public()
         ->alias('knp_snappy.pdf', Knp\Snappy\Pdf::class)
         ;


### PR DESCRIPTION
https://github.com/KnpLabs/KnpSnappyBundle/pull/350 broke the service definition while refactoring from the XML to the PHP format. The correct tag name is `monolog.logger`, not `monolog.setLogger` (https://github.com/symfony/monolog-bundle/blob/v4.0.1/src/DependencyInjection/Compiler/LoggerChannelPass.php#L41).

This then results with the following errors when building the Symfony container in my app:

```
In LoggerChannelPass.php line 100:

Monolog configuration error: The logging channel "snappy" assigned to the "main" handler does not exist.

In ContainerBuilder.php line 1048:

You have requested a non-existent service "monolog.logger.snappy".
```